### PR TITLE
feat: create Swap entities only for Kittycorn pools

### DIFF
--- a/src/mappings/swap.ts
+++ b/src/mappings/swap.ts
@@ -177,22 +177,25 @@ export function handleSwapHelper(event: SwapEvent, subgraphConfig: SubgraphConfi
     token0.totalValueLockedUSD = token0.totalValueLocked.times(token0.derivedETH).times(bundle.ethPriceUSD)
     token1.totalValueLockedUSD = token1.totalValueLocked.times(token1.derivedETH).times(bundle.ethPriceUSD)
 
-    // create Swap event
+    // create Swap event only for Kittycorn pools
     const transaction = loadTransaction(event)
-    const swap = new Swap(transaction.id + '-' + event.logIndex.toString())
-    swap.transaction = transaction.id
-    swap.timestamp = transaction.timestamp
-    swap.pool = pool.id
-    swap.token0 = pool.token0
-    swap.token1 = pool.token1
-    swap.sender = event.params.sender
-    swap.origin = event.transaction.from
-    swap.amount0 = amount0
-    swap.amount1 = amount1
-    swap.amountUSD = amountTotalUSDTracked
-    swap.tick = BigInt.fromI32(event.params.tick as i32)
-    swap.sqrtPriceX96 = event.params.sqrtPriceX96
-    swap.logIndex = event.logIndex
+    let swap: Swap | null = null
+    if (poolCollateral !== null) {
+      swap = new Swap(transaction.id + '-' + event.logIndex.toString())
+      swap.transaction = transaction.id
+      swap.timestamp = transaction.timestamp
+      swap.pool = pool.id
+      swap.token0 = pool.token0
+      swap.token1 = pool.token1
+      swap.sender = event.params.sender
+      swap.origin = event.transaction.from
+      swap.amount0 = amount0
+      swap.amount1 = amount1
+      swap.amountUSD = amountTotalUSDTracked
+      swap.tick = BigInt.fromI32(event.params.tick as i32)
+      swap.sqrtPriceX96 = event.params.sqrtPriceX96
+      swap.logIndex = event.logIndex
+    }
 
     // interval data
     const uniswapDayData = updateUniswapDayData(event, poolManagerAddress)
@@ -251,7 +254,9 @@ export function handleSwapHelper(event: SwapEvent, subgraphConfig: SubgraphConfi
     token1HourData.feesUSD = token1HourData.feesUSD.plus(feesUSD)
 
     kittycornPositionManager.save()
-    swap.save()
+    if (swap !== null) {
+      swap.save()
+    }
     token0DayData.save()
     token1DayData.save()
     uniswapDayData.save()


### PR DESCRIPTION
## Summary
- Wrap Swap entity creation inside `poolCollateral !== null` check
- Only save swap when it exists (for Kittycorn pools)
- Ensures `swaps` query returns only Kittycorn pool swaps, matching `UserSwapDayData` behavior

## Changes
Previously, `Swap` entities were created for ALL pools, while `UserSwapDayData` was only created for Kittycorn pools. This caused inconsistency where the swap history API would return swaps from non-Kittycorn pools.

Now both entities are only created for Kittycorn pools (pools with `PoolAllowCollateral` entry).

| Entity | Kittycorn Pools Only? |
|--------|----------------------|
| `Swap` | ✅ Yes |
| `UserSwapDayData` | ✅ Yes |

## Test plan
- [x] Build succeeds (`yarn build`)
- [x] Deploy to testnet and verify only Kittycorn pool swaps are indexed